### PR TITLE
feat(cli): add Amp and Codex to built-in agents

### DIFF
--- a/apps/cli/src/commands/agent.rs
+++ b/apps/cli/src/commands/agent.rs
@@ -84,6 +84,8 @@ pub async fn run(cmd: AgentCommand) -> Result<()> {
                 "copilot",
                 "goose",
                 "opencode",
+                "amp",
+                "codex",
             ];
             if builtins.contains(&name.as_str()) {
                 bail!(

--- a/apps/cli/src/commands/core/config.rs
+++ b/apps/cli/src/commands/core/config.rs
@@ -184,6 +184,28 @@ impl Config {
             },
         );
 
+        agents.insert(
+            "amp".to_string(),
+            AgentConfig {
+                name: "Amp".to_string(),
+                skills_dir: dirs::config_dir()
+                    .map(|c| c.join("agents").join("skills"))
+                    .unwrap_or_else(|| PathBuf::from("~/.config/agents/skills")),
+                description: Some("Sourcegraph's Amp coding agent".to_string()),
+            },
+        );
+
+        agents.insert(
+            "codex".to_string(),
+            AgentConfig {
+                name: "Codex".to_string(),
+                skills_dir: dirs::home_dir()
+                    .map(|h| h.join(".codex").join("skills"))
+                    .unwrap_or_else(|| PathBuf::from("~/.codex/skills")),
+                description: Some("OpenAI's Codex coding agent".to_string()),
+            },
+        );
+
         agents
     }
 


### PR DESCRIPTION
- Add Amp (Sourcegraph) with skills dir at ~/.config/agents/skills
- Add Codex (OpenAI) with skills dir at ~/.codex/skills
- Update builtins list in agent.rs to prevent removal