### PR TITLE
fix: remove User-Agent header to fix CORS preflight

### DIFF
--- a/packages/api/typescript/src/client.ts
+++ b/packages/api/typescript/src/client.ts
@@ -190,7 +190,6 @@ export class PaksClient {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
       Accept: 'application/json',
-      'User-Agent': 'paks-api-ts/0.1.0',
     };
 
     if (this.authToken && (requireAuth || this.authToken)) {


### PR DESCRIPTION
The browser was sending Access-Control-Request-Headers: content-type,user-agent in the OPTIONS preflight request, but the server wasn't allowing user-agent in its CORS config. Removing the custom User-Agent header from the client since browsers handle this automatically.