### PR TITLE
feat(cli): implement search command with registry API

### DIFF
--- a/apps/cli/src/commands/search.rs
+++ b/apps/cli/src/commands/search.rs
@@ -1,6 +1,7 @@
 //! Search command - search for skills in the registry
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+use paks_api::{PaksClient, SearchPaksQuery};
 
 pub struct SearchArgs {
     pub query: String,
@@ -8,12 +9,77 @@ pub struct SearchArgs {
 }
 
 pub async fn run(args: SearchArgs) -> Result<()> {
-    println!("Searching for: {} (limit: {})", args.query, args.limit);
+    // Create API client
+    let client = PaksClient::builder()
+        .base_url("https://apiv2.stakpak.dev")
+        .build()
+        .context("Failed to create API client")?;
 
-    // TODO: Implement skill search
-    // 1. Query registry API
-    // 2. Display results in table format
-    // 3. Show name, description, version, author
+    // Build search query
+    let query = SearchPaksQuery {
+        query: Some(args.query.clone()),
+        limit: Some(args.limit as u32),
+        ..Default::default()
+    };
+
+    // Execute search
+    let mut results = client
+        .search_paks(query)
+        .await
+        .context("Failed to search registry")?;
+
+    if results.is_empty() {
+        println!("\n  No skills found matching '{}'\n", args.query);
+        return Ok(());
+    }
+
+    // Sort by downloads (descending)
+    results.sort_by(|a, b| b.total_downloads.cmp(&a.total_downloads));
+
+    println!();
+    for pak in results {
+        // First line: owner/name + stats
+        let downloads = format_count(pak.total_downloads);
+        print!(
+            "  \x1b[1;36m{}\x1b[0m/\x1b[1m{}\x1b[0m \x1b[2m↓{}\x1b[0m",
+            pak.owner_name, pak.name, downloads
+        );
+
+        // Tags inline (up to 3)
+        if !pak.tags.is_empty() {
+            let tags: String = pak
+                .tags
+                .iter()
+                .take(3)
+                .map(|t| format!("\x1b[33m#{}\x1b[0m", t))
+                .collect::<Vec<_>>()
+                .join(" ");
+            print!("  {}", tags);
+        }
+        println!();
+
+        // Description on second line
+        if let Some(desc) = &pak.description {
+            let truncated: String = desc.chars().take(72).collect();
+            let suffix = if desc.len() > 72 { "…" } else { "" };
+            println!("    \x1b[2m{}{}\x1b[0m", truncated, suffix);
+        }
+    }
+
+    println!(
+        "\n  \x1b[2mInstall: paks install <owner>/<skill>\x1b[0m\n"
+    );
 
     Ok(())
+}
+
+/// Format large numbers with K/M suffixes
+fn format_count(n: i64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}K", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
 }


### PR DESCRIPTION
## Summary
Implements the `paks search` command that was previously a stub.

## Changes
- Wire up search command to registry API via `PaksClient::search_paks()`
- Display results sorted by downloads (descending)
- Compact two-line format showing:
  - Owner/name, download count, and up to 3 tags
  - Description (truncated to 72 chars)
- Install hint at bottom

## Example Output
```
  stakpak/aws-sso-auth-guide ↓3  #aws #sso #authentication
    AWS SSO discovery, configuration, and terminal usage
  stakpak/simple-deployment-on-vm ↓3  #aws #deploy #security
    How to do simple but secure deployments using virtual machines...

  Install: paks install <owner>/<skill>
```