### PR TITLE
Add third-party OSS attribution notices

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,1205 @@
+# Third-Party Software Notices for `paks`
+
+This product includes third-party open-source software components listed below. Each component remains under its own license; copies of those licenses are available from the respective package registries / project repositories.
+
+Total components: 1197
+
+| Component | Version | Ecosystem | License |
+|-----------|---------|-----------|---------|
+| android_system_properties | 0.1.5 | cargo | Apache-2.0 OR MIT |
+| anstream | 0.6.21 | cargo | Apache-2.0 OR MIT |
+| anstyle | 1.0.13 | cargo | Apache-2.0 OR MIT |
+| anstyle-parse | 0.2.7 | cargo | Apache-2.0 OR MIT |
+| anstyle-query | 1.1.5 | cargo | Apache-2.0 OR MIT |
+| anstyle-wincon | 3.0.11 | cargo | Apache-2.0 OR MIT |
+| anyhow | 1.0.100 | cargo | Apache-2.0 OR MIT |
+| atomic-waker | 1.1.2 | cargo | Apache-2.0 OR MIT |
+| autocfg | 1.5.0 | cargo | Apache-2.0 OR MIT |
+| base64 | 0.22.1 | cargo | Apache-2.0 OR MIT |
+| bitflags | 2.10.0 | cargo | Apache-2.0 OR MIT |
+| bumpalo | 3.19.1 | cargo | Apache-2.0 OR MIT |
+| bytes | 1.11.0 | cargo | MIT |
+| cc | 1.2.50 | cargo | Apache-2.0 OR MIT |
+| cfg-if | 1.0.4 | cargo | Apache-2.0 OR MIT |
+| cfg_aliases | 0.2.1 | cargo | MIT |
+| chrono | 0.4.42 | cargo | Apache-2.0 OR MIT |
+| clap | 4.5.53 | cargo | Apache-2.0 OR MIT |
+| clap_builder | 4.5.53 | cargo | Apache-2.0 OR MIT |
+| clap_derive | 4.5.49 | cargo | Apache-2.0 OR MIT |
+| clap_lex | 0.7.6 | cargo | Apache-2.0 OR MIT |
+| colorchoice | 1.0.4 | cargo | Apache-2.0 OR MIT |
+| console | 0.15.11 | cargo | MIT |
+| core-foundation-sys | 0.8.7 | cargo | Apache-2.0 OR MIT |
+| dialoguer | 0.11.0 | cargo | MIT |
+| dirs | 6.0.0 | cargo | Apache-2.0 OR MIT |
+| dirs-sys | 0.5.0 | cargo | Apache-2.0 OR MIT |
+| displaydoc | 0.2.5 | cargo | Apache-2.0 OR MIT |
+| dyn-clone | 1.0.20 | cargo | Apache-2.0 OR MIT |
+| encode_unicode | 1.0.0 | cargo | Apache-2.0 OR MIT |
+| equivalent | 1.0.2 | cargo | Apache-2.0 OR MIT |
+| errno | 0.3.14 | cargo | Apache-2.0 OR MIT |
+| fastrand | 2.3.0 | cargo | Apache-2.0 OR MIT |
+| find-msvc-tools | 0.1.5 | cargo | Apache-2.0 OR MIT |
+| form_urlencoded | 1.2.2 | cargo | Apache-2.0 OR MIT |
+| futures-channel | 0.3.31 | cargo | Apache-2.0 OR MIT |
+| futures-core | 0.3.31 | cargo | Apache-2.0 OR MIT |
+| futures-task | 0.3.31 | cargo | Apache-2.0 OR MIT |
+| futures-util | 0.3.31 | cargo | Apache-2.0 OR MIT |
+| getrandom | 0.2.16 | cargo | Apache-2.0 OR MIT |
+| getrandom | 0.3.4 | cargo | Apache-2.0 OR MIT |
+| hashbrown | 0.16.1 | cargo | Apache-2.0 OR MIT |
+| heck | 0.5.0 | cargo | Apache-2.0 OR MIT |
+| http | 1.4.0 | cargo | Apache-2.0 OR MIT |
+| http-body | 1.0.1 | cargo | MIT |
+| http-body-util | 0.1.3 | cargo | MIT |
+| httparse | 1.10.1 | cargo | Apache-2.0 OR MIT |
+| hyper | 1.8.1 | cargo | MIT |
+| hyper-rustls | 0.27.7 | cargo | Apache-2.0 OR ISC OR MIT |
+| hyper-util | 0.1.19 | cargo | MIT |
+| iana-time-zone | 0.1.64 | cargo | Apache-2.0 OR MIT |
+| iana-time-zone-haiku | 0.1.2 | cargo | Apache-2.0 OR MIT |
+| icu_collections | 2.1.1 | cargo | Unicode-3.0 |
+| icu_locale_core | 2.1.1 | cargo | Unicode-3.0 |
+| icu_normalizer | 2.1.1 | cargo | Unicode-3.0 |
+| icu_normalizer_data | 2.1.1 | cargo | Unicode-3.0 |
+| icu_properties | 2.1.2 | cargo | Unicode-3.0 |
+| icu_properties_data | 2.1.2 | cargo | Unicode-3.0 |
+| icu_provider | 2.1.1 | cargo | Unicode-3.0 |
+| idna | 1.1.0 | cargo | Apache-2.0 OR MIT |
+| idna_adapter | 1.2.1 | cargo | Apache-2.0 OR MIT |
+| indexmap | 2.12.1 | cargo | Apache-2.0 OR MIT |
+| ipnet | 2.11.0 | cargo | Apache-2.0 OR MIT |
+| iri-string | 0.7.9 | cargo | Apache-2.0 OR MIT |
+| is_terminal_polyfill | 1.70.2 | cargo | Apache-2.0 OR MIT |
+| itoa | 1.0.16 | cargo | Apache-2.0 OR MIT |
+| js-sys | 0.3.83 | cargo | Apache-2.0 OR MIT |
+| libc | 0.2.178 | cargo | Apache-2.0 OR MIT |
+| libredox | 0.1.11 | cargo | MIT |
+| linux-raw-sys | 0.11.0 | cargo | Apache-2.0 OR MIT OR Apache-2.0 WITH LLVM-exception |
+| litemap | 0.8.1 | cargo | Unicode-3.0 |
+| lock_api | 0.4.14 | cargo | Apache-2.0 OR MIT |
+| log | 0.4.29 | cargo | Apache-2.0 OR MIT |
+| lru-slab | 0.1.2 | cargo | Apache-2.0 OR MIT OR Zlib |
+| memchr | 2.7.6 | cargo | MIT OR Unlicense |
+| mio | 1.1.1 | cargo | MIT |
+| num-traits | 0.2.19 | cargo | Apache-2.0 OR MIT |
+| once_cell | 1.21.3 | cargo | Apache-2.0 OR MIT |
+| once_cell_polyfill | 1.70.2 | cargo | Apache-2.0 OR MIT |
+| option-ext | 0.2.0 | cargo | MPL-2.0 |
+| paks-api | 0.1.18 | cargo | UNKNOWN |
+| paks-api-schema | 0.1.18 | cargo | UNKNOWN |
+| paks-cli | 0.1.18 | cargo | UNKNOWN |
+| paks-core | 0.1.18 | cargo | UNKNOWN |
+| parking_lot | 0.12.5 | cargo | Apache-2.0 OR MIT |
+| parking_lot_core | 0.9.12 | cargo | Apache-2.0 OR MIT |
+| percent-encoding | 2.3.2 | cargo | Apache-2.0 OR MIT |
+| pin-project-lite | 0.2.16 | cargo | Apache-2.0 OR MIT |
+| pin-utils | 0.1.0 | cargo | Apache-2.0 OR MIT |
+| potential_utf | 0.1.4 | cargo | Unicode-3.0 |
+| ppv-lite86 | 0.2.21 | cargo | Apache-2.0 OR MIT |
+| proc-macro2 | 1.0.103 | cargo | Apache-2.0 OR MIT |
+| quinn | 0.11.9 | cargo | Apache-2.0 OR MIT |
+| quinn-proto | 0.11.13 | cargo | Apache-2.0 OR MIT |
+| quinn-udp | 0.5.14 | cargo | Apache-2.0 OR MIT |
+| quote | 1.0.42 | cargo | Apache-2.0 OR MIT |
+| r-efi | 5.3.0 | cargo | Apache-2.0 OR LGPL-2.1-or-later OR MIT |
+| rand | 0.9.2 | cargo | Apache-2.0 OR MIT |
+| rand_chacha | 0.9.0 | cargo | Apache-2.0 OR MIT |
+| rand_core | 0.9.3 | cargo | Apache-2.0 OR MIT |
+| redox_syscall | 0.5.18 | cargo | MIT |
+| redox_users | 0.5.2 | cargo | MIT |
+| reqwest | 0.12.28 | cargo | Apache-2.0 OR MIT |
+| ring | 0.17.14 | cargo | Apache-2.0 AND ISC |
+| rustc-hash | 2.1.1 | cargo | Apache-2.0 OR MIT |
+| rustix | 1.1.2 | cargo | Apache-2.0 OR MIT OR Apache-2.0 WITH LLVM-exception |
+| rustls | 0.23.35 | cargo | Apache-2.0 OR ISC OR MIT |
+| rustls-pki-types | 1.13.2 | cargo | Apache-2.0 OR MIT |
+| rustls-webpki | 0.103.8 | cargo | ISC |
+| rustversion | 1.0.22 | cargo | Apache-2.0 OR MIT |
+| ryu | 1.0.21 | cargo | Apache-2.0 OR BSL-1.0 |
+| schemars | 0.8.22 | cargo | MIT |
+| schemars_derive | 0.8.22 | cargo | MIT |
+| scopeguard | 1.2.0 | cargo | Apache-2.0 OR MIT |
+| serde | 1.0.228 | cargo | Apache-2.0 OR MIT |
+| serde_core | 1.0.228 | cargo | Apache-2.0 OR MIT |
+| serde_derive | 1.0.228 | cargo | Apache-2.0 OR MIT |
+| serde_derive_internals | 0.29.1 | cargo | Apache-2.0 OR MIT |
+| serde_json | 1.0.146 | cargo | Apache-2.0 OR MIT |
+| serde_spanned | 0.6.9 | cargo | Apache-2.0 OR MIT |
+| serde_urlencoded | 0.7.1 | cargo | Apache-2.0 OR MIT |
+| serde_yaml_ng | 0.10.0 | cargo | MIT |
+| shell-words | 1.1.1 | cargo | Apache-2.0 OR MIT |
+| shellexpand | 3.1.1 | cargo | Apache-2.0 OR MIT |
+| shlex | 1.3.0 | cargo | Apache-2.0 OR MIT |
+| signal-hook-registry | 1.4.7 | cargo | Apache-2.0 OR MIT |
+| slab | 0.4.11 | cargo | MIT |
+| smallvec | 1.15.1 | cargo | Apache-2.0 OR MIT |
+| socket2 | 0.6.1 | cargo | Apache-2.0 OR MIT |
+| stable_deref_trait | 1.2.1 | cargo | Apache-2.0 OR MIT |
+| strsim | 0.11.1 | cargo | MIT |
+| subtle | 2.6.1 | cargo | BSD-3-Clause |
+| syn | 2.0.111 | cargo | Apache-2.0 OR MIT |
+| sync_wrapper | 1.0.2 | cargo | Apache-2.0 |
+| synstructure | 0.13.2 | cargo | MIT |
+| tempfile | 3.23.0 | cargo | Apache-2.0 OR MIT |
+| thiserror | 1.0.69 | cargo | Apache-2.0 OR MIT |
+| thiserror | 2.0.17 | cargo | Apache-2.0 OR MIT |
+| thiserror-impl | 1.0.69 | cargo | Apache-2.0 OR MIT |
+| thiserror-impl | 2.0.17 | cargo | Apache-2.0 OR MIT |
+| tinystr | 0.8.2 | cargo | Unicode-3.0 |
+| tinyvec | 1.10.0 | cargo | Apache-2.0 OR MIT OR Zlib |
+| tinyvec_macros | 0.1.1 | cargo | Apache-2.0 OR MIT OR Zlib |
+| tokio | 1.48.0 | cargo | MIT |
+| tokio-macros | 2.6.0 | cargo | MIT |
+| tokio-rustls | 0.26.4 | cargo | Apache-2.0 OR MIT |
+| toml | 0.8.23 | cargo | Apache-2.0 OR MIT |
+| toml_datetime | 0.6.11 | cargo | Apache-2.0 OR MIT |
+| toml_edit | 0.22.27 | cargo | Apache-2.0 OR MIT |
+| toml_write | 0.1.2 | cargo | Apache-2.0 OR MIT |
+| tower | 0.5.2 | cargo | MIT |
+| tower-http | 0.6.8 | cargo | MIT |
+| tower-layer | 0.3.3 | cargo | MIT |
+| tower-service | 0.3.3 | cargo | MIT |
+| tracing | 0.1.44 | cargo | MIT |
+| tracing-core | 0.1.36 | cargo | MIT |
+| try-lock | 0.2.5 | cargo | MIT |
+| unicode-ident | 1.0.22 | cargo | Unicode-3.0 AND (Apache-2.0 OR MIT) |
+| unicode-width | 0.2.2 | cargo | Apache-2.0 OR MIT |
+| unsafe-libyaml | 0.2.11 | cargo | MIT |
+| untrusted | 0.9.0 | cargo | ISC |
+| url | 2.5.7 | cargo | Apache-2.0 OR MIT |
+| urlencoding | 2.1.3 | cargo | MIT |
+| utf8_iter | 1.0.4 | cargo | Apache-2.0 OR MIT |
+| utf8parse | 0.2.2 | cargo | Apache-2.0 OR MIT |
+| uuid | 1.19.0 | cargo | Apache-2.0 OR MIT |
+| want | 0.3.1 | cargo | MIT |
+| wasi | 0.11.1+wasi-snapshot-preview1 | cargo | UNKNOWN |
+| wasip2 | 1.0.1+wasi-0.2.4 | cargo | UNKNOWN |
+| wasm-bindgen | 0.2.106 | cargo | Apache-2.0 OR MIT |
+| wasm-bindgen-futures | 0.4.56 | cargo | Apache-2.0 OR MIT |
+| wasm-bindgen-macro | 0.2.106 | cargo | Apache-2.0 OR MIT |
+| wasm-bindgen-macro-support | 0.2.106 | cargo | Apache-2.0 OR MIT |
+| wasm-bindgen-shared | 0.2.106 | cargo | Apache-2.0 OR MIT |
+| web-sys | 0.3.83 | cargo | Apache-2.0 OR MIT |
+| web-time | 1.1.0 | cargo | Apache-2.0 OR MIT |
+| webpki-roots | 1.0.4 | cargo | CDLA-Permissive-2.0 |
+| windows-core | 0.62.2 | cargo | Apache-2.0 OR MIT |
+| windows-implement | 0.60.2 | cargo | Apache-2.0 OR MIT |
+| windows-interface | 0.59.3 | cargo | Apache-2.0 OR MIT |
+| windows-link | 0.2.1 | cargo | Apache-2.0 OR MIT |
+| windows-result | 0.4.1 | cargo | Apache-2.0 OR MIT |
+| windows-strings | 0.5.1 | cargo | Apache-2.0 OR MIT |
+| windows-sys | 0.52.0 | cargo | Apache-2.0 OR MIT |
+| windows-sys | 0.59.0 | cargo | Apache-2.0 OR MIT |
+| windows-sys | 0.60.2 | cargo | Apache-2.0 OR MIT |
+| windows-sys | 0.61.2 | cargo | Apache-2.0 OR MIT |
+| windows-targets | 0.52.6 | cargo | Apache-2.0 OR MIT |
+| windows-targets | 0.53.5 | cargo | Apache-2.0 OR MIT |
+| windows_aarch64_gnullvm | 0.52.6 | cargo | Apache-2.0 OR MIT |
+| windows_aarch64_gnullvm | 0.53.1 | cargo | Apache-2.0 OR MIT |
+| windows_aarch64_msvc | 0.52.6 | cargo | Apache-2.0 OR MIT |
+| windows_aarch64_msvc | 0.53.1 | cargo | Apache-2.0 OR MIT |
+| windows_i686_gnu | 0.52.6 | cargo | Apache-2.0 OR MIT |
+| windows_i686_gnu | 0.53.1 | cargo | Apache-2.0 OR MIT |
+| windows_i686_gnullvm | 0.52.6 | cargo | Apache-2.0 OR MIT |
+| windows_i686_gnullvm | 0.53.1 | cargo | Apache-2.0 OR MIT |
+| windows_i686_msvc | 0.52.6 | cargo | Apache-2.0 OR MIT |
+| windows_i686_msvc | 0.53.1 | cargo | Apache-2.0 OR MIT |
+| windows_x86_64_gnu | 0.52.6 | cargo | Apache-2.0 OR MIT |
+| windows_x86_64_gnu | 0.53.1 | cargo | Apache-2.0 OR MIT |
+| windows_x86_64_gnullvm | 0.52.6 | cargo | Apache-2.0 OR MIT |
+| windows_x86_64_gnullvm | 0.53.1 | cargo | Apache-2.0 OR MIT |
+| windows_x86_64_msvc | 0.52.6 | cargo | Apache-2.0 OR MIT |
+| windows_x86_64_msvc | 0.53.1 | cargo | Apache-2.0 OR MIT |
+| winnow | 0.7.14 | cargo | MIT |
+| wit-bindgen | 0.46.0 | cargo | Apache-2.0 OR MIT OR Apache-2.0 WITH LLVM-exception |
+| writeable | 0.6.2 | cargo | Unicode-3.0 |
+| yoke | 0.8.1 | cargo | Unicode-3.0 |
+| yoke-derive | 0.8.1 | cargo | Unicode-3.0 |
+| zerocopy | 0.8.31 | cargo | Apache-2.0 OR BSD-2-Clause OR MIT |
+| zerocopy-derive | 0.8.31 | cargo | Apache-2.0 OR BSD-2-Clause OR MIT |
+| zerofrom | 0.1.6 | cargo | Unicode-3.0 |
+| zerofrom-derive | 0.1.6 | cargo | Unicode-3.0 |
+| zeroize | 1.8.2 | cargo | Apache-2.0 OR MIT |
+| zerotrie | 0.2.3 | cargo | Unicode-3.0 |
+| zerovec | 0.11.5 | cargo | Unicode-3.0 |
+| zerovec-derive | 0.11.2 | cargo | Unicode-3.0 |
+| @antfu/ni | 25.0.0 | npm | MIT |
+| @apidevtools/json-schema-ref-parser | 11.9.3 | npm | MIT |
+| @asamuzakjp/css-color | 3.2.0 | npm | MIT |
+| @babel/code-frame | 7.26.2 | npm | MIT |
+| @babel/code-frame | 7.27.1 | npm | MIT |
+| @babel/compat-data | 7.28.5 | npm | MIT |
+| @babel/core | 7.28.5 | npm | MIT |
+| @babel/generator | 7.28.5 | npm | MIT |
+| @babel/helper-annotate-as-pure | 7.27.3 | npm | MIT |
+| @babel/helper-compilation-targets | 7.27.2 | npm | MIT |
+| @babel/helper-create-class-features-plugin | 7.28.5 | npm | MIT |
+| @babel/helper-globals | 7.28.0 | npm | MIT |
+| @babel/helper-member-expression-to-functions | 7.28.5 | npm | MIT |
+| @babel/helper-module-imports | 7.27.1 | npm | MIT |
+| @babel/helper-module-transforms | 7.28.3 | npm | MIT |
+| @babel/helper-optimise-call-expression | 7.27.1 | npm | MIT |
+| @babel/helper-plugin-utils | 7.27.1 | npm | MIT |
+| @babel/helper-replace-supers | 7.27.1 | npm | MIT |
+| @babel/helper-skip-transparent-expression-wrappers | 7.27.1 | npm | MIT |
+| @babel/helper-string-parser | 7.27.1 | npm | MIT |
+| @babel/helper-validator-identifier | 7.28.5 | npm | MIT |
+| @babel/helper-validator-option | 7.27.1 | npm | MIT |
+| @babel/helpers | 7.28.4 | npm | MIT |
+| @babel/parser | 7.28.5 | npm | MIT |
+| @babel/plugin-syntax-jsx | 7.27.1 | npm | MIT |
+| @babel/plugin-syntax-typescript | 7.27.1 | npm | MIT |
+| @babel/plugin-transform-modules-commonjs | 7.27.1 | npm | MIT |
+| @babel/plugin-transform-react-jsx-self | 7.27.1 | npm | MIT |
+| @babel/plugin-transform-react-jsx-source | 7.27.1 | npm | MIT |
+| @babel/plugin-transform-typescript | 7.28.5 | npm | MIT |
+| @babel/preset-typescript | 7.28.5 | npm | MIT |
+| @babel/runtime | 7.28.4 | npm | MIT |
+| @babel/template | 7.27.2 | npm | MIT |
+| @babel/traverse | 7.28.5 | npm | MIT |
+| @babel/types | 7.28.5 | npm | MIT |
+| @base-ui/react | 1.0.0 | npm | MIT |
+| @base-ui/utils | 0.2.3 | npm | MIT |
+| @csstools/color-helpers | 5.1.0 | npm | MIT-0 |
+| @csstools/css-calc | 2.1.4 | npm | MIT |
+| @csstools/css-color-parser | 3.1.0 | npm | MIT |
+| @csstools/css-parser-algorithms | 3.0.5 | npm | MIT |
+| @csstools/css-tokenizer | 3.0.4 | npm | MIT |
+| @dotenvx/dotenvx | 1.51.2 | npm | BSD-3-Clause |
+| @ecies/ciphers | 0.2.5 | npm | MIT |
+| @emnapi/core | 1.7.1 | npm | MIT |
+| @emnapi/runtime | 1.7.1 | npm | MIT |
+| @emnapi/wasi-threads | 1.1.0 | npm | MIT |
+| @esbuild/aix-ppc64 | 0.27.2 | npm | MIT |
+| @esbuild/android-arm | 0.27.2 | npm | MIT |
+| @esbuild/android-arm64 | 0.27.2 | npm | MIT |
+| @esbuild/android-x64 | 0.27.2 | npm | MIT |
+| @esbuild/darwin-arm64 | 0.27.2 | npm | MIT |
+| @esbuild/darwin-x64 | 0.27.2 | npm | MIT |
+| @esbuild/freebsd-arm64 | 0.27.2 | npm | MIT |
+| @esbuild/freebsd-x64 | 0.27.2 | npm | MIT |
+| @esbuild/linux-arm | 0.27.2 | npm | MIT |
+| @esbuild/linux-arm64 | 0.27.2 | npm | MIT |
+| @esbuild/linux-ia32 | 0.27.2 | npm | MIT |
+| @esbuild/linux-loong64 | 0.27.2 | npm | MIT |
+| @esbuild/linux-mips64el | 0.27.2 | npm | MIT |
+| @esbuild/linux-ppc64 | 0.27.2 | npm | MIT |
+| @esbuild/linux-riscv64 | 0.27.2 | npm | MIT |
+| @esbuild/linux-s390x | 0.27.2 | npm | MIT |
+| @esbuild/linux-x64 | 0.27.2 | npm | MIT |
+| @esbuild/netbsd-arm64 | 0.27.2 | npm | MIT |
+| @esbuild/netbsd-x64 | 0.27.2 | npm | MIT |
+| @esbuild/openbsd-arm64 | 0.27.2 | npm | MIT |
+| @esbuild/openbsd-x64 | 0.27.2 | npm | MIT |
+| @esbuild/openharmony-arm64 | 0.27.2 | npm | MIT |
+| @esbuild/sunos-x64 | 0.27.2 | npm | MIT |
+| @esbuild/win32-arm64 | 0.27.2 | npm | MIT |
+| @esbuild/win32-ia32 | 0.27.2 | npm | MIT |
+| @esbuild/win32-x64 | 0.27.2 | npm | MIT |
+| @floating-ui/core | 1.7.3 | npm | MIT |
+| @floating-ui/dom | 1.7.4 | npm | MIT |
+| @floating-ui/react-dom | 2.1.6 | npm | MIT |
+| @floating-ui/utils | 0.2.10 | npm | MIT |
+| @fontsource-variable/jetbrains-mono | 5.2.8 | npm | OFL-1.1 |
+| @formatjs/intl-localematcher | 0.7.2 | npm | MIT |
+| @fumadocs/ui | 16.3.2 | npm | MIT |
+| @hono/node-server | 1.19.7 | npm | MIT |
+| @inquirer/ansi | 1.0.2 | npm | MIT |
+| @inquirer/confirm | 5.1.21 | npm | MIT |
+| @inquirer/core | 10.3.2 | npm | MIT |
+| @inquirer/figures | 1.0.15 | npm | MIT |
+| @inquirer/type | 3.0.10 | npm | MIT |
+| @isaacs/balanced-match | 4.0.1 | npm | MIT |
+| @isaacs/brace-expansion | 5.0.0 | npm | MIT |
+| @jridgewell/gen-mapping | 0.3.13 | npm | MIT |
+| @jridgewell/remapping | 2.3.5 | npm | MIT |
+| @jridgewell/resolve-uri | 3.1.2 | npm | MIT |
+| @jridgewell/sourcemap-codec | 1.5.5 | npm | MIT |
+| @jridgewell/trace-mapping | 0.3.31 | npm | MIT |
+| @jsdevtools/ono | 7.1.3 | npm | MIT |
+| @mdx-js/mdx | 3.1.1 | npm | MIT |
+| @modelcontextprotocol/sdk | 1.25.1 | npm | MIT |
+| @mswjs/interceptors | 0.40.0 | npm | MIT |
+| @napi-rs/wasm-runtime | 1.1.0 | npm | MIT |
+| @noble/ciphers | 1.3.0 | npm | MIT |
+| @noble/curves | 1.9.7 | npm | MIT |
+| @noble/hashes | 1.8.0 | npm | MIT |
+| @nodelib/fs.scandir | 2.1.5 | npm | MIT |
+| @nodelib/fs.stat | 2.0.5 | npm | MIT |
+| @nodelib/fs.walk | 1.2.8 | npm | MIT |
+| @oozcitak/dom | 2.0.2 | npm | MIT |
+| @oozcitak/infra | 2.0.2 | npm | MIT |
+| @oozcitak/url | 3.0.0 | npm | MIT |
+| @oozcitak/util | 10.0.0 | npm | MIT |
+| @open-draft/deferred-promise | 2.2.0 | npm | MIT |
+| @open-draft/logger | 0.3.0 | npm | MIT |
+| @open-draft/until | 2.1.0 | npm | MIT |
+| @orama/orama | 3.1.18 | npm | Apache-2.0 |
+| @oxc-minify/binding-android-arm64 | 0.96.0 | npm | MIT |
+| @oxc-minify/binding-darwin-arm64 | 0.96.0 | npm | MIT |
+| @oxc-minify/binding-darwin-x64 | 0.96.0 | npm | MIT |
+| @oxc-minify/binding-freebsd-x64 | 0.96.0 | npm | MIT |
+| @oxc-minify/binding-linux-arm-gnueabihf | 0.96.0 | npm | MIT |
+| @oxc-minify/binding-linux-arm-musleabihf | 0.96.0 | npm | MIT |
+| @oxc-minify/binding-linux-arm64-gnu | 0.96.0 | npm | MIT |
+| @oxc-minify/binding-linux-arm64-musl | 0.96.0 | npm | MIT |
+| @oxc-minify/binding-linux-riscv64-gnu | 0.96.0 | npm | MIT |
+| @oxc-minify/binding-linux-s390x-gnu | 0.96.0 | npm | MIT |
+| @oxc-minify/binding-linux-x64-gnu | 0.96.0 | npm | MIT |
+| @oxc-minify/binding-linux-x64-musl | 0.96.0 | npm | MIT |
+| @oxc-minify/binding-wasm32-wasi | 0.96.0 | npm | MIT |
+| @oxc-minify/binding-win32-arm64-msvc | 0.96.0 | npm | MIT |
+| @oxc-minify/binding-win32-x64-msvc | 0.96.0 | npm | MIT |
+| @oxc-transform/binding-android-arm64 | 0.96.0 | npm | MIT |
+| @oxc-transform/binding-darwin-arm64 | 0.96.0 | npm | MIT |
+| @oxc-transform/binding-darwin-x64 | 0.96.0 | npm | MIT |
+| @oxc-transform/binding-freebsd-x64 | 0.96.0 | npm | MIT |
+| @oxc-transform/binding-linux-arm-gnueabihf | 0.96.0 | npm | MIT |
+| @oxc-transform/binding-linux-arm-musleabihf | 0.96.0 | npm | MIT |
+| @oxc-transform/binding-linux-arm64-gnu | 0.96.0 | npm | MIT |
+| @oxc-transform/binding-linux-arm64-musl | 0.96.0 | npm | MIT |
+| @oxc-transform/binding-linux-riscv64-gnu | 0.96.0 | npm | MIT |
+| @oxc-transform/binding-linux-s390x-gnu | 0.96.0 | npm | MIT |
+| @oxc-transform/binding-linux-x64-gnu | 0.96.0 | npm | MIT |
+| @oxc-transform/binding-linux-x64-musl | 0.96.0 | npm | MIT |
+| @oxc-transform/binding-wasm32-wasi | 0.96.0 | npm | MIT |
+| @oxc-transform/binding-win32-arm64-msvc | 0.96.0 | npm | MIT |
+| @oxc-transform/binding-win32-x64-msvc | 0.96.0 | npm | MIT |
+| @oxfmt/darwin-arm64 | 0.19.0 | npm | MIT |
+| @oxfmt/darwin-x64 | 0.19.0 | npm | MIT |
+| @oxfmt/linux-arm64-gnu | 0.19.0 | npm | MIT |
+| @oxfmt/linux-arm64-musl | 0.19.0 | npm | MIT |
+| @oxfmt/linux-x64-gnu | 0.19.0 | npm | MIT |
+| @oxfmt/linux-x64-musl | 0.19.0 | npm | MIT |
+| @oxfmt/win32-arm64 | 0.19.0 | npm | MIT |
+| @oxfmt/win32-x64 | 0.19.0 | npm | MIT |
+| @oxlint/darwin-arm64 | 1.35.0 | npm | MIT |
+| @oxlint/darwin-x64 | 1.35.0 | npm | MIT |
+| @oxlint/linux-arm64-gnu | 1.35.0 | npm | MIT |
+| @oxlint/linux-arm64-musl | 1.35.0 | npm | MIT |
+| @oxlint/linux-x64-gnu | 1.35.0 | npm | MIT |
+| @oxlint/linux-x64-musl | 1.35.0 | npm | MIT |
+| @oxlint/win32-arm64 | 1.35.0 | npm | MIT |
+| @oxlint/win32-x64 | 1.35.0 | npm | MIT |
+| @posthog/core | 1.9.0 | npm | MIT |
+| @radix-ui/number | 1.1.1 | npm | MIT |
+| @radix-ui/primitive | 1.1.3 | npm | MIT |
+| @radix-ui/react-accessible-icon | 1.1.7 | npm | MIT |
+| @radix-ui/react-accordion | 1.2.12 | npm | MIT |
+| @radix-ui/react-alert-dialog | 1.1.15 | npm | MIT |
+| @radix-ui/react-arrow | 1.1.7 | npm | MIT |
+| @radix-ui/react-aspect-ratio | 1.1.7 | npm | MIT |
+| @radix-ui/react-avatar | 1.1.10 | npm | MIT |
+| @radix-ui/react-checkbox | 1.3.3 | npm | MIT |
+| @radix-ui/react-collapsible | 1.1.12 | npm | MIT |
+| @radix-ui/react-collection | 1.1.7 | npm | MIT |
+| @radix-ui/react-compose-refs | 1.1.2 | npm | MIT |
+| @radix-ui/react-context | 1.1.2 | npm | MIT |
+| @radix-ui/react-context-menu | 2.2.16 | npm | MIT |
+| @radix-ui/react-dialog | 1.1.15 | npm | MIT |
+| @radix-ui/react-direction | 1.1.1 | npm | MIT |
+| @radix-ui/react-dismissable-layer | 1.1.11 | npm | MIT |
+| @radix-ui/react-dropdown-menu | 2.1.16 | npm | MIT |
+| @radix-ui/react-focus-guards | 1.1.3 | npm | MIT |
+| @radix-ui/react-focus-scope | 1.1.7 | npm | MIT |
+| @radix-ui/react-form | 0.1.8 | npm | MIT |
+| @radix-ui/react-hover-card | 1.1.15 | npm | MIT |
+| @radix-ui/react-id | 1.1.1 | npm | MIT |
+| @radix-ui/react-label | 2.1.7 | npm | MIT |
+| @radix-ui/react-menu | 2.1.16 | npm | MIT |
+| @radix-ui/react-menubar | 1.1.16 | npm | MIT |
+| @radix-ui/react-navigation-menu | 1.2.14 | npm | MIT |
+| @radix-ui/react-one-time-password-field | 0.1.8 | npm | MIT |
+| @radix-ui/react-password-toggle-field | 0.1.3 | npm | MIT |
+| @radix-ui/react-popover | 1.1.15 | npm | MIT |
+| @radix-ui/react-popper | 1.2.8 | npm | MIT |
+| @radix-ui/react-portal | 1.1.9 | npm | MIT |
+| @radix-ui/react-presence | 1.1.5 | npm | MIT |
+| @radix-ui/react-primitive | 2.1.3 | npm | MIT |
+| @radix-ui/react-progress | 1.1.7 | npm | MIT |
+| @radix-ui/react-radio-group | 1.3.8 | npm | MIT |
+| @radix-ui/react-roving-focus | 1.1.11 | npm | MIT |
+| @radix-ui/react-scroll-area | 1.2.10 | npm | MIT |
+| @radix-ui/react-select | 2.2.6 | npm | MIT |
+| @radix-ui/react-separator | 1.1.7 | npm | MIT |
+| @radix-ui/react-slider | 1.3.6 | npm | MIT |
+| @radix-ui/react-slot | 1.2.3 | npm | MIT |
+| @radix-ui/react-slot | 1.2.4 | npm | MIT |
+| @radix-ui/react-switch | 1.2.6 | npm | MIT |
+| @radix-ui/react-tabs | 1.1.13 | npm | MIT |
+| @radix-ui/react-toast | 1.2.15 | npm | MIT |
+| @radix-ui/react-toggle | 1.1.10 | npm | MIT |
+| @radix-ui/react-toggle-group | 1.1.11 | npm | MIT |
+| @radix-ui/react-toolbar | 1.1.11 | npm | MIT |
+| @radix-ui/react-tooltip | 1.2.8 | npm | MIT |
+| @radix-ui/react-use-callback-ref | 1.1.1 | npm | MIT |
+| @radix-ui/react-use-controllable-state | 1.2.2 | npm | MIT |
+| @radix-ui/react-use-effect-event | 0.0.2 | npm | MIT |
+| @radix-ui/react-use-escape-keydown | 1.1.1 | npm | MIT |
+| @radix-ui/react-use-is-hydrated | 0.1.0 | npm | MIT |
+| @radix-ui/react-use-layout-effect | 1.1.1 | npm | MIT |
+| @radix-ui/react-use-previous | 1.1.1 | npm | MIT |
+| @radix-ui/react-use-rect | 1.1.1 | npm | MIT |
+| @radix-ui/react-use-size | 1.1.1 | npm | MIT |
+| @radix-ui/react-visually-hidden | 1.2.3 | npm | MIT |
+| @radix-ui/rect | 1.1.1 | npm | MIT |
+| @resvg/resvg-js | 2.6.2 | npm | MPL-2.0 |
+| @resvg/resvg-js-android-arm-eabi | 2.6.2 | npm | MPL-2.0 |
+| @resvg/resvg-js-android-arm64 | 2.6.2 | npm | MPL-2.0 |
+| @resvg/resvg-js-darwin-arm64 | 2.6.2 | npm | MPL-2.0 |
+| @resvg/resvg-js-darwin-x64 | 2.6.2 | npm | MPL-2.0 |
+| @resvg/resvg-js-linux-arm-gnueabihf | 2.6.2 | npm | MPL-2.0 |
+| @resvg/resvg-js-linux-arm64-gnu | 2.6.2 | npm | MPL-2.0 |
+| @resvg/resvg-js-linux-arm64-musl | 2.6.2 | npm | MPL-2.0 |
+| @resvg/resvg-js-linux-x64-gnu | 2.6.2 | npm | MPL-2.0 |
+| @resvg/resvg-js-linux-x64-musl | 2.6.2 | npm | MPL-2.0 |
+| @resvg/resvg-js-win32-arm64-msvc | 2.6.2 | npm | MPL-2.0 |
+| @resvg/resvg-js-win32-ia32-msvc | 2.6.2 | npm | MPL-2.0 |
+| @resvg/resvg-js-win32-x64-msvc | 2.6.2 | npm | MPL-2.0 |
+| @rolldown/pluginutils | 1.0.0-beta.40 | npm | MIT |
+| @rolldown/pluginutils | 1.0.0-beta.53 | npm | MIT |
+| @rollup/rollup-android-arm-eabi | 4.54.0 | npm | MIT |
+| @rollup/rollup-android-arm64 | 4.54.0 | npm | MIT |
+| @rollup/rollup-darwin-arm64 | 4.54.0 | npm | MIT |
+| @rollup/rollup-darwin-x64 | 4.54.0 | npm | MIT |
+| @rollup/rollup-freebsd-arm64 | 4.54.0 | npm | MIT |
+| @rollup/rollup-freebsd-x64 | 4.54.0 | npm | MIT |
+| @rollup/rollup-linux-arm-gnueabihf | 4.54.0 | npm | MIT |
+| @rollup/rollup-linux-arm-musleabihf | 4.54.0 | npm | MIT |
+| @rollup/rollup-linux-arm64-gnu | 4.54.0 | npm | MIT |
+| @rollup/rollup-linux-arm64-musl | 4.54.0 | npm | MIT |
+| @rollup/rollup-linux-loong64-gnu | 4.54.0 | npm | MIT |
+| @rollup/rollup-linux-ppc64-gnu | 4.54.0 | npm | MIT |
+| @rollup/rollup-linux-riscv64-gnu | 4.54.0 | npm | MIT |
+| @rollup/rollup-linux-riscv64-musl | 4.54.0 | npm | MIT |
+| @rollup/rollup-linux-s390x-gnu | 4.54.0 | npm | MIT |
+| @rollup/rollup-linux-x64-gnu | 4.54.0 | npm | MIT |
+| @rollup/rollup-linux-x64-musl | 4.54.0 | npm | MIT |
+| @rollup/rollup-openharmony-arm64 | 4.54.0 | npm | MIT |
+| @rollup/rollup-win32-arm64-msvc | 4.54.0 | npm | MIT |
+| @rollup/rollup-win32-ia32-msvc | 4.54.0 | npm | MIT |
+| @rollup/rollup-win32-x64-gnu | 4.54.0 | npm | MIT |
+| @rollup/rollup-win32-x64-msvc | 4.54.0 | npm | MIT |
+| @sec-ant/readable-stream | 0.4.1 | npm | MIT |
+| @shikijs/core | 3.20.0 | npm | MIT |
+| @shikijs/engine-javascript | 3.20.0 | npm | MIT |
+| @shikijs/engine-oniguruma | 3.20.0 | npm | MIT |
+| @shikijs/langs | 3.20.0 | npm | MIT |
+| @shikijs/rehype | 3.20.0 | npm | MIT |
+| @shikijs/themes | 3.20.0 | npm | MIT |
+| @shikijs/transformers | 3.20.0 | npm | MIT |
+| @shikijs/types | 3.20.0 | npm | MIT |
+| @shikijs/vscode-textmate | 10.0.2 | npm | MIT |
+| @shuding/opentype.js | 1.4.0-beta.0 | npm | MIT |
+| @sindresorhus/merge-streams | 4.0.0 | npm | MIT |
+| @standard-schema/spec | 1.1.0 | npm | MIT |
+| @tailwindcss/node | 4.1.18 | npm | MIT |
+| @tailwindcss/oxide | 4.1.18 | npm | MIT |
+| @tailwindcss/oxide-android-arm64 | 4.1.18 | npm | MIT |
+| @tailwindcss/oxide-darwin-arm64 | 4.1.18 | npm | MIT |
+| @tailwindcss/oxide-darwin-x64 | 4.1.18 | npm | MIT |
+| @tailwindcss/oxide-freebsd-x64 | 4.1.18 | npm | MIT |
+| @tailwindcss/oxide-linux-arm-gnueabihf | 4.1.18 | npm | MIT |
+| @tailwindcss/oxide-linux-arm64-gnu | 4.1.18 | npm | MIT |
+| @tailwindcss/oxide-linux-arm64-musl | 4.1.18 | npm | MIT |
+| @tailwindcss/oxide-linux-x64-gnu | 4.1.18 | npm | MIT |
+| @tailwindcss/oxide-linux-x64-musl | 4.1.18 | npm | MIT |
+| @tailwindcss/oxide-wasm32-wasi | 4.1.18 | npm | MIT |
+| @tailwindcss/oxide-win32-arm64-msvc | 4.1.18 | npm | MIT |
+| @tailwindcss/oxide-win32-x64-msvc | 4.1.18 | npm | MIT |
+| @tailwindcss/typography | 0.5.19 | npm | MIT |
+| @tailwindcss/vite | 4.1.18 | npm | MIT |
+| @tanstack/devtools-event-client | 0.4.0 | npm | MIT |
+| @tanstack/directive-functions-plugin | 1.134.5 | npm | MIT |
+| @tanstack/directive-functions-plugin | 1.142.1 | npm | MIT |
+| @tanstack/form-core | 1.27.6 | npm | MIT |
+| @tanstack/history | 1.133.28 | npm | MIT |
+| @tanstack/history | 1.141.0 | npm | MIT |
+| @tanstack/pacer-lite | 0.1.1 | npm | MIT |
+| @tanstack/query-core | 5.90.12 | npm | MIT |
+| @tanstack/query-devtools | 5.91.1 | npm | MIT |
+| @tanstack/react-form | 1.27.6 | npm | MIT |
+| @tanstack/react-query | 5.90.12 | npm | MIT |
+| @tanstack/react-query-devtools | 5.91.1 | npm | MIT |
+| @tanstack/react-router | 1.136.18 | npm | MIT |
+| @tanstack/react-router | 1.142.8 | npm | MIT |
+| @tanstack/react-router-devtools | 1.136.18 | npm | MIT |
+| @tanstack/react-router-devtools | 1.142.8 | npm | MIT |
+| @tanstack/react-router-with-query | 1.130.17 | npm | MIT |
+| @tanstack/react-start | 1.136.18 | npm | MIT |
+| @tanstack/react-start | 1.142.8 | npm | MIT |
+| @tanstack/react-start-client | 1.136.18 | npm | MIT |
+| @tanstack/react-start-client | 1.142.8 | npm | MIT |
+| @tanstack/react-start-server | 1.136.18 | npm | MIT |
+| @tanstack/react-start-server | 1.142.8 | npm | MIT |
+| @tanstack/react-store | 0.8.0 | npm | MIT |
+| @tanstack/router-core | 1.136.17 | npm | MIT |
+| @tanstack/router-core | 1.142.8 | npm | MIT |
+| @tanstack/router-devtools-core | 1.136.17 | npm | MIT |
+| @tanstack/router-devtools-core | 1.142.8 | npm | MIT |
+| @tanstack/router-generator | 1.136.17 | npm | MIT |
+| @tanstack/router-generator | 1.142.8 | npm | MIT |
+| @tanstack/router-plugin | 1.136.18 | npm | MIT |
+| @tanstack/router-plugin | 1.142.8 | npm | MIT |
+| @tanstack/router-utils | 1.133.19 | npm | MIT |
+| @tanstack/router-utils | 1.141.0 | npm | MIT |
+| @tanstack/server-functions-plugin | 1.134.5 | npm | MIT |
+| @tanstack/server-functions-plugin | 1.142.1 | npm | MIT |
+| @tanstack/start-client-core | 1.136.17 | npm | MIT |
+| @tanstack/start-client-core | 1.142.8 | npm | MIT |
+| @tanstack/start-plugin-core | 1.136.18 | npm | MIT |
+| @tanstack/start-plugin-core | 1.142.8 | npm | MIT |
+| @tanstack/start-server-core | 1.136.17 | npm | MIT |
+| @tanstack/start-server-core | 1.142.8 | npm | MIT |
+| @tanstack/start-storage-context | 1.136.17 | npm | MIT |
+| @tanstack/start-storage-context | 1.142.8 | npm | MIT |
+| @tanstack/store | 0.7.7 | npm | MIT |
+| @tanstack/store | 0.8.0 | npm | MIT |
+| @tanstack/virtual-file-routes | 1.133.19 | npm | MIT |
+| @tanstack/virtual-file-routes | 1.141.0 | npm | MIT |
+| @testing-library/dom | 10.4.1 | npm | MIT |
+| @testing-library/react | 16.3.1 | npm | MIT |
+| @ts-morph/common | 0.27.0 | npm | MIT |
+| @tybys/wasm-util | 0.10.1 | npm | MIT |
+| @types/aria-query | 5.0.4 | npm | MIT |
+| @types/babel__core | 7.20.5 | npm | MIT |
+| @types/babel__generator | 7.27.0 | npm | MIT |
+| @types/babel__template | 7.4.4 | npm | MIT |
+| @types/babel__traverse | 7.28.0 | npm | MIT |
+| @types/debug | 4.1.12 | npm | MIT |
+| @types/estree | 1.0.8 | npm | MIT |
+| @types/estree-jsx | 1.0.5 | npm | MIT |
+| @types/hast | 3.0.4 | npm | MIT |
+| @types/json-schema | 7.0.15 | npm | MIT |
+| @types/lodash | 4.17.21 | npm | MIT |
+| @types/mdast | 4.0.4 | npm | MIT |
+| @types/mdx | 2.0.13 | npm | MIT |
+| @types/ms | 2.1.0 | npm | MIT |
+| @types/node | 24.10.4 | npm | MIT |
+| @types/prismjs | 1.26.5 | npm | MIT |
+| @types/react | 19.2.7 | npm | MIT |
+| @types/react-dom | 19.2.3 | npm | MIT |
+| @types/react-syntax-highlighter | 15.5.13 | npm | MIT |
+| @types/statuses | 2.0.6 | npm | MIT |
+| @types/unist | 2.0.11 | npm | MIT |
+| @types/unist | 3.0.3 | npm | MIT |
+| @ungap/structured-clone | 1.3.0 | npm | ISC |
+| @vitejs/plugin-react | 5.1.2 | npm | MIT |
+| accepts | 2.0.0 | npm | MIT |
+| acorn | 8.15.0 | npm | MIT |
+| acorn-jsx | 5.3.2 | npm | MIT |
+| agent-base | 7.1.4 | npm | MIT |
+| ajv | 8.17.1 | npm | MIT |
+| ajv-formats | 3.0.1 | npm | MIT |
+| ansi-regex | 5.0.1 | npm | MIT |
+| ansi-regex | 6.2.2 | npm | MIT |
+| ansi-styles | 4.3.0 | npm | MIT |
+| ansi-styles | 5.2.0 | npm | MIT |
+| ansis | 4.2.0 | npm | ISC |
+| anymatch | 3.1.3 | npm | ISC |
+| argparse | 2.0.1 | npm | Python-2.0 |
+| aria-hidden | 1.2.6 | npm | MIT |
+| aria-query | 5.3.0 | npm | Apache-2.0 |
+| ast-types | 0.16.1 | npm | MIT |
+| astring | 1.9.0 | npm | MIT |
+| babel-dead-code-elimination | 1.0.11 | npm | MIT |
+| bail | 2.0.2 | npm | MIT |
+| base64-js | 0.0.8 | npm | MIT |
+| baseline-browser-mapping | 2.9.11 | npm | Apache-2.0 |
+| binary-extensions | 2.3.0 | npm | MIT |
+| body-parser | 2.2.1 | npm | MIT |
+| boolbase | 1.0.0 | npm | ISC |
+| braces | 3.0.3 | npm | MIT |
+| browserslist | 4.28.1 | npm | MIT |
+| bundle-name | 4.1.0 | npm | MIT |
+| bytes | 3.1.2 | npm | MIT |
+| call-bind-apply-helpers | 1.0.2 | npm | MIT |
+| call-bound | 1.0.4 | npm | MIT |
+| callsites | 3.1.0 | npm | MIT |
+| camelize | 1.0.1 | npm | MIT |
+| caniuse-lite | 1.0.30001761 | npm | CC-BY-4.0 |
+| ccount | 2.0.1 | npm | MIT |
+| chalk | 5.6.2 | npm | MIT |
+| character-entities | 2.0.2 | npm | MIT |
+| character-entities-html4 | 2.1.0 | npm | MIT |
+| character-entities-legacy | 3.0.0 | npm | MIT |
+| character-reference-invalid | 2.0.1 | npm | MIT |
+| cheerio | 1.1.2 | npm | MIT |
+| cheerio-select | 2.1.0 | npm | BSD-2-Clause |
+| chokidar | 3.6.0 | npm | MIT |
+| chokidar | 5.0.0 | npm | MIT |
+| class-variance-authority | 0.7.1 | npm | Apache-2.0 |
+| cli-cursor | 5.0.0 | npm | MIT |
+| cli-spinners | 2.9.2 | npm | MIT |
+| cli-width | 4.1.0 | npm | ISC |
+| cliui | 8.0.1 | npm | ISC |
+| clsx | 2.1.1 | npm | MIT |
+| code-block-writer | 13.0.3 | npm | MIT |
+| collapse-white-space | 2.1.0 | npm | MIT |
+| color-convert | 2.0.1 | npm | MIT |
+| color-name | 1.1.4 | npm | MIT |
+| comma-separated-tokens | 2.0.3 | npm | MIT |
+| commander | 11.1.0 | npm | MIT |
+| commander | 14.0.2 | npm | MIT |
+| compute-scroll-into-view | 3.1.1 | npm | MIT |
+| consola | 3.4.2 | npm | MIT |
+| content-disposition | 1.0.1 | npm | MIT |
+| content-type | 1.0.5 | npm | MIT |
+| convert-source-map | 2.0.0 | npm | MIT |
+| cookie | 0.7.2 | npm | MIT |
+| cookie | 1.1.1 | npm | MIT |
+| cookie-es | 2.0.0 | npm | MIT |
+| cookie-signature | 1.2.2 | npm | MIT |
+| core-js | 3.47.0 | npm | MIT |
+| cors | 2.8.5 | npm | MIT |
+| cosmiconfig | 9.0.0 | npm | MIT |
+| cross-spawn | 7.0.6 | npm | MIT |
+| crossws | 0.4.1 | npm | MIT |
+| css-background-parser | 0.1.0 | npm | MIT |
+| css-box-shadow | 1.0.0-3 | npm | MIT |
+| css-color-keywords | 1.0.0 | npm | ISC |
+| css-gradient-parser | 0.0.17 | npm | MIT |
+| css-select | 5.2.2 | npm | BSD-2-Clause |
+| css-to-react-native | 3.2.0 | npm | MIT |
+| css-what | 6.2.2 | npm | BSD-2-Clause |
+| cssesc | 3.0.0 | npm | MIT |
+| cssstyle | 4.6.0 | npm | MIT |
+| csstype | 3.2.3 | npm | MIT |
+| data-uri-to-buffer | 4.0.1 | npm | MIT |
+| data-urls | 5.0.0 | npm | MIT |
+| db0 | 0.3.4 | npm | MIT |
+| debug | 4.4.3 | npm | MIT |
+| decimal.js | 10.6.0 | npm | MIT |
+| decode-named-character-reference | 1.2.0 | npm | MIT |
+| dedent | 1.7.1 | npm | MIT |
+| deepmerge | 4.3.1 | npm | MIT |
+| default-browser | 5.4.0 | npm | MIT |
+| default-browser-id | 5.0.1 | npm | MIT |
+| define-lazy-prop | 3.0.0 | npm | MIT |
+| depd | 2.0.0 | npm | MIT |
+| dequal | 2.0.3 | npm | MIT |
+| detect-libc | 2.1.2 | npm | Apache-2.0 |
+| detect-node-es | 1.1.0 | npm | MIT |
+| devlop | 1.1.0 | npm | MIT |
+| diff | 8.0.2 | npm | BSD-3-Clause |
+| dom-accessibility-api | 0.5.16 | npm | MIT |
+| dom-serializer | 2.0.0 | npm | MIT |
+| domelementtype | 2.3.0 | npm | BSD-2-Clause |
+| domhandler | 5.0.3 | npm | BSD-2-Clause |
+| domutils | 3.2.2 | npm | BSD-2-Clause |
+| dotenv | 17.2.3 | npm | BSD-2-Clause |
+| dunder-proto | 1.0.1 | npm | MIT |
+| eciesjs | 0.4.16 | npm | MIT |
+| ee-first | 1.1.1 | npm | MIT |
+| electron-to-chromium | 1.5.267 | npm | ISC |
+| emoji-regex | 10.6.0 | npm | MIT |
+| emoji-regex | 8.0.0 | npm | MIT |
+| emoji-regex-xs | 2.0.1 | npm | MIT |
+| encodeurl | 2.0.0 | npm | MIT |
+| encoding-sniffer | 0.2.1 | npm | MIT |
+| enhanced-resolve | 5.18.4 | npm | MIT |
+| entities | 4.5.0 | npm | BSD-2-Clause |
+| entities | 6.0.1 | npm | BSD-2-Clause |
+| env-paths | 2.2.1 | npm | MIT |
+| error-ex | 1.3.4 | npm | MIT |
+| es-define-property | 1.0.1 | npm | MIT |
+| es-errors | 1.3.0 | npm | MIT |
+| es-object-atoms | 1.1.1 | npm | MIT |
+| esast-util-from-estree | 2.0.0 | npm | MIT |
+| esast-util-from-js | 2.0.1 | npm | MIT |
+| esbuild | 0.27.2 | npm | MIT |
+| escalade | 3.2.0 | npm | MIT |
+| escape-html | 1.0.3 | npm | MIT |
+| escape-string-regexp | 5.0.0 | npm | MIT |
+| esprima | 4.0.1 | npm | BSD-2-Clause |
+| estree-util-attach-comments | 3.0.0 | npm | MIT |
+| estree-util-build-jsx | 3.0.1 | npm | MIT |
+| estree-util-is-identifier-name | 3.0.0 | npm | MIT |
+| estree-util-scope | 1.0.0 | npm | MIT |
+| estree-util-to-js | 2.0.0 | npm | MIT |
+| estree-util-value-to-estree | 3.5.0 | npm | MIT |
+| estree-util-visit | 2.0.0 | npm | MIT |
+| estree-walker | 3.0.3 | npm | MIT |
+| etag | 1.8.1 | npm | MIT |
+| eventsource | 3.0.7 | npm | MIT |
+| eventsource-parser | 3.0.6 | npm | MIT |
+| execa | 5.1.1 | npm | MIT |
+| execa | 9.6.1 | npm | MIT |
+| express | 5.2.1 | npm | MIT |
+| express-rate-limit | 7.5.1 | npm | MIT |
+| exsolve | 1.0.8 | npm | MIT |
+| extend | 3.0.2 | npm | MIT |
+| fast-deep-equal | 3.1.3 | npm | MIT |
+| fast-glob | 3.3.3 | npm | MIT |
+| fast-uri | 3.1.0 | npm | BSD-3-Clause |
+| fastq | 1.19.1 | npm | ISC |
+| fault | 1.0.4 | npm | MIT |
+| fdir | 6.5.0 | npm | MIT |
+| fetch-blob | 3.2.0 | npm | MIT |
+| fetchdts | 0.1.7 | npm | MIT |
+| fflate | 0.4.8 | npm | MIT |
+| fflate | 0.7.4 | npm | MIT |
+| figures | 6.1.0 | npm | MIT |
+| fill-range | 7.1.1 | npm | MIT |
+| finalhandler | 2.1.1 | npm | MIT |
+| format | 0.2.2 | npm | UNKNOWN |
+| formdata-polyfill | 4.0.10 | npm | MIT |
+| forwarded | 0.2.0 | npm | MIT |
+| fresh | 2.0.0 | npm | MIT |
+| fs-extra | 11.3.3 | npm | MIT |
+| fsevents | 2.3.3 | npm | MIT |
+| fumadocs-core | 16.3.2 | npm | MIT |
+| fumadocs-mdx | 14.2.2 | npm | MIT |
+| fumadocs-ui | 16.3.2 | npm | MIT |
+| function-bind | 1.1.2 | npm | MIT |
+| fuzzysort | 3.1.0 | npm | MIT |
+| fzf | 0.5.2 | npm | BSD-3-Clause |
+| gensync | 1.0.0-beta.2 | npm | MIT |
+| get-caller-file | 2.0.5 | npm | ISC |
+| get-east-asian-width | 1.4.0 | npm | MIT |
+| get-intrinsic | 1.3.0 | npm | MIT |
+| get-nonce | 1.0.1 | npm | MIT |
+| get-own-enumerable-keys | 1.0.0 | npm | MIT |
+| get-proto | 1.0.1 | npm | MIT |
+| get-stream | 6.0.1 | npm | MIT |
+| get-stream | 9.0.1 | npm | MIT |
+| get-tsconfig | 4.13.0 | npm | MIT |
+| github-slugger | 2.0.0 | npm | ISC |
+| glob-parent | 5.1.2 | npm | ISC |
+| globrex | 0.1.2 | npm | MIT |
+| goober | 2.1.18 | npm | MIT |
+| gopd | 1.2.0 | npm | MIT |
+| graceful-fs | 4.2.11 | npm | ISC |
+| graphql | 16.12.0 | npm | MIT |
+| h3 | 2.0.0-beta.4 | npm | MIT |
+| h3 | 2.0.1-rc.5 | npm | MIT |
+| h3 | 2.0.1-rc.6 | npm | MIT |
+| has-symbols | 1.1.0 | npm | MIT |
+| hasown | 2.0.2 | npm | MIT |
+| hast-util-parse-selector | 4.0.0 | npm | MIT |
+| hast-util-to-estree | 3.1.3 | npm | MIT |
+| hast-util-to-html | 9.0.5 | npm | MIT |
+| hast-util-to-jsx-runtime | 2.3.6 | npm | MIT |
+| hast-util-to-string | 3.0.1 | npm | MIT |
+| hast-util-whitespace | 3.0.0 | npm | MIT |
+| hastscript | 9.0.1 | npm | MIT |
+| headers-polyfill | 4.0.3 | npm | MIT |
+| hex-rgb | 4.3.0 | npm | MIT |
+| highlight.js | 10.7.3 | npm | BSD-3-Clause |
+| highlightjs-vue | 1.0.0 | npm | CC0-1.0 |
+| hono | 4.11.1 | npm | MIT |
+| html-encoding-sniffer | 4.0.0 | npm | MIT |
+| html-url-attributes | 3.0.1 | npm | MIT |
+| html-void-elements | 3.0.0 | npm | MIT |
+| htmlparser2 | 10.0.0 | npm | MIT |
+| http-errors | 2.0.1 | npm | MIT |
+| http-proxy-agent | 7.0.2 | npm | MIT |
+| https-proxy-agent | 7.0.6 | npm | MIT |
+| human-signals | 2.1.0 | npm | Apache-2.0 |
+| human-signals | 8.0.1 | npm | Apache-2.0 |
+| iconv-lite | 0.6.3 | npm | MIT |
+| iconv-lite | 0.7.1 | npm | MIT |
+| ignore | 5.3.2 | npm | MIT |
+| image-size | 2.0.2 | npm | MIT |
+| import-fresh | 3.3.1 | npm | MIT |
+| inherits | 2.0.4 | npm | ISC |
+| inline-style-parser | 0.2.7 | npm | MIT |
+| ipaddr.js | 1.9.1 | npm | MIT |
+| is-alphabetical | 2.0.1 | npm | MIT |
+| is-alphanumerical | 2.0.1 | npm | MIT |
+| is-arrayish | 0.2.1 | npm | MIT |
+| is-binary-path | 2.1.0 | npm | MIT |
+| is-decimal | 2.0.1 | npm | MIT |
+| is-docker | 3.0.0 | npm | MIT |
+| is-extglob | 2.1.1 | npm | MIT |
+| is-fullwidth-code-point | 3.0.0 | npm | MIT |
+| is-glob | 4.0.3 | npm | MIT |
+| is-hexadecimal | 2.0.1 | npm | MIT |
+| is-in-ssh | 1.0.0 | npm | MIT |
+| is-inside-container | 1.0.0 | npm | MIT |
+| is-interactive | 2.0.0 | npm | MIT |
+| is-node-process | 1.2.0 | npm | MIT |
+| is-number | 7.0.0 | npm | MIT |
+| is-obj | 3.0.0 | npm | MIT |
+| is-plain-obj | 4.1.0 | npm | MIT |
+| is-potential-custom-element-name | 1.0.1 | npm | MIT |
+| is-promise | 4.0.0 | npm | MIT |
+| is-regexp | 3.1.0 | npm | MIT |
+| is-stream | 2.0.1 | npm | MIT |
+| is-stream | 4.0.1 | npm | MIT |
+| is-unicode-supported | 1.3.0 | npm | MIT |
+| is-unicode-supported | 2.1.0 | npm | MIT |
+| is-wsl | 3.1.0 | npm | MIT |
+| isbot | 5.1.32 | npm | Unlicense |
+| isexe | 2.0.0 | npm | ISC |
+| isexe | 3.1.1 | npm | ISC |
+| jiti | 2.6.1 | npm | MIT |
+| jose | 6.1.3 | npm | MIT |
+| js-tokens | 4.0.0 | npm | MIT |
+| js-yaml | 4.1.1 | npm | MIT |
+| jsdom | 26.1.0 | npm | MIT |
+| jsesc | 3.1.0 | npm | MIT |
+| json-parse-even-better-errors | 2.3.1 | npm | MIT |
+| json-schema-to-typescript | 15.0.4 | npm | MIT |
+| json-schema-traverse | 1.0.0 | npm | MIT |
+| json-schema-typed | 8.0.2 | npm | BSD-2-Clause |
+| json5 | 2.2.3 | npm | MIT |
+| jsonfile | 6.2.0 | npm | MIT |
+| kleur | 3.0.3 | npm | MIT |
+| kleur | 4.1.5 | npm | MIT |
+| lightningcss | 1.30.2 | npm | MPL-2.0 |
+| lightningcss-android-arm64 | 1.30.2 | npm | MPL-2.0 |
+| lightningcss-darwin-arm64 | 1.30.2 | npm | MPL-2.0 |
+| lightningcss-darwin-x64 | 1.30.2 | npm | MPL-2.0 |
+| lightningcss-freebsd-x64 | 1.30.2 | npm | MPL-2.0 |
+| lightningcss-linux-arm-gnueabihf | 1.30.2 | npm | MPL-2.0 |
+| lightningcss-linux-arm64-gnu | 1.30.2 | npm | MPL-2.0 |
+| lightningcss-linux-arm64-musl | 1.30.2 | npm | MPL-2.0 |
+| lightningcss-linux-x64-gnu | 1.30.2 | npm | MPL-2.0 |
+| lightningcss-linux-x64-musl | 1.30.2 | npm | MPL-2.0 |
+| lightningcss-win32-arm64-msvc | 1.30.2 | npm | MPL-2.0 |
+| lightningcss-win32-x64-msvc | 1.30.2 | npm | MPL-2.0 |
+| linebreak | 1.1.0 | npm | MIT |
+| lines-and-columns | 1.2.4 | npm | MIT |
+| lodash | 4.17.21 | npm | MIT |
+| lodash.merge | 4.6.2 | npm | MIT |
+| log-symbols | 6.0.0 | npm | MIT |
+| longest-streak | 3.1.0 | npm | MIT |
+| lowlight | 1.20.0 | npm | MIT |
+| lru-cache | 10.4.3 | npm | ISC |
+| lru-cache | 5.1.1 | npm | ISC |
+| lucide-react | 0.525.0 | npm | ISC |
+| lucide-react | 0.561.0 | npm | ISC |
+| lz-string | 1.5.0 | npm | MIT |
+| magic-string | 0.30.21 | npm | MIT |
+| markdown-extensions | 2.0.0 | npm | MIT |
+| markdown-table | 3.0.4 | npm | MIT |
+| math-intrinsics | 1.1.0 | npm | MIT |
+| mdast-util-find-and-replace | 3.0.2 | npm | MIT |
+| mdast-util-from-markdown | 2.0.2 | npm | MIT |
+| mdast-util-gfm | 3.1.0 | npm | MIT |
+| mdast-util-gfm-autolink-literal | 2.0.1 | npm | MIT |
+| mdast-util-gfm-footnote | 2.1.0 | npm | MIT |
+| mdast-util-gfm-strikethrough | 2.0.0 | npm | MIT |
+| mdast-util-gfm-table | 2.0.0 | npm | MIT |
+| mdast-util-gfm-task-list-item | 2.0.0 | npm | MIT |
+| mdast-util-mdx | 3.0.0 | npm | MIT |
+| mdast-util-mdx-expression | 2.0.1 | npm | MIT |
+| mdast-util-mdx-jsx | 3.2.0 | npm | MIT |
+| mdast-util-mdxjs-esm | 2.0.1 | npm | MIT |
+| mdast-util-phrasing | 4.1.0 | npm | MIT |
+| mdast-util-to-hast | 13.2.1 | npm | MIT |
+| mdast-util-to-markdown | 2.1.2 | npm | MIT |
+| mdast-util-to-string | 4.0.0 | npm | MIT |
+| media-typer | 1.1.0 | npm | MIT |
+| merge-descriptors | 2.0.0 | npm | MIT |
+| merge-stream | 2.0.0 | npm | MIT |
+| merge2 | 1.4.1 | npm | MIT |
+| micromark | 4.0.2 | npm | MIT |
+| micromark-core-commonmark | 2.0.3 | npm | MIT |
+| micromark-extension-gfm | 3.0.0 | npm | MIT |
+| micromark-extension-gfm-autolink-literal | 2.1.0 | npm | MIT |
+| micromark-extension-gfm-footnote | 2.1.0 | npm | MIT |
+| micromark-extension-gfm-strikethrough | 2.1.0 | npm | MIT |
+| micromark-extension-gfm-table | 2.1.1 | npm | MIT |
+| micromark-extension-gfm-tagfilter | 2.0.0 | npm | MIT |
+| micromark-extension-gfm-task-list-item | 2.1.0 | npm | MIT |
+| micromark-extension-mdx-expression | 3.0.1 | npm | MIT |
+| micromark-extension-mdx-jsx | 3.0.2 | npm | MIT |
+| micromark-extension-mdx-md | 2.0.0 | npm | MIT |
+| micromark-extension-mdxjs | 3.0.0 | npm | MIT |
+| micromark-extension-mdxjs-esm | 3.0.0 | npm | MIT |
+| micromark-factory-destination | 2.0.1 | npm | MIT |
+| micromark-factory-label | 2.0.1 | npm | MIT |
+| micromark-factory-mdx-expression | 2.0.3 | npm | MIT |
+| micromark-factory-space | 2.0.1 | npm | MIT |
+| micromark-factory-title | 2.0.1 | npm | MIT |
+| micromark-factory-whitespace | 2.0.1 | npm | MIT |
+| micromark-util-character | 2.1.1 | npm | MIT |
+| micromark-util-chunked | 2.0.1 | npm | MIT |
+| micromark-util-classify-character | 2.0.1 | npm | MIT |
+| micromark-util-combine-extensions | 2.0.1 | npm | MIT |
+| micromark-util-decode-numeric-character-reference | 2.0.2 | npm | MIT |
+| micromark-util-decode-string | 2.0.1 | npm | MIT |
+| micromark-util-encode | 2.0.1 | npm | MIT |
+| micromark-util-events-to-acorn | 2.0.3 | npm | MIT |
+| micromark-util-html-tag-name | 2.0.1 | npm | MIT |
+| micromark-util-normalize-identifier | 2.0.1 | npm | MIT |
+| micromark-util-resolve-all | 2.0.1 | npm | MIT |
+| micromark-util-sanitize-uri | 2.0.1 | npm | MIT |
+| micromark-util-subtokenize | 2.1.0 | npm | MIT |
+| micromark-util-symbol | 2.0.1 | npm | MIT |
+| micromark-util-types | 2.0.2 | npm | MIT |
+| micromatch | 4.0.8 | npm | MIT |
+| mime-db | 1.54.0 | npm | MIT |
+| mime-types | 3.0.2 | npm | MIT |
+| mimic-fn | 2.1.0 | npm | MIT |
+| mimic-function | 5.0.1 | npm | MIT |
+| minimatch | 10.1.1 | npm | BlueOak-1.0.0 |
+| minimist | 1.2.8 | npm | MIT |
+| ms | 2.1.3 | npm | MIT |
+| msw | 2.12.4 | npm | MIT |
+| mute-stream | 2.0.0 | npm | ISC |
+| nanoid | 3.3.11 | npm | MIT |
+| negotiator | 1.0.0 | npm | MIT |
+| next-themes | 0.4.6 | npm | MIT |
+| nf3 | 0.1.12 | npm | MIT |
+| nitro | 3.0.1-alpha.1 | npm | MIT |
+| node-domexception | 1.0.0 | npm | MIT |
+| node-fetch | 3.3.2 | npm | MIT |
+| node-releases | 2.0.27 | npm | MIT |
+| normalize-path | 3.0.0 | npm | MIT |
+| npm-run-path | 4.0.1 | npm | MIT |
+| npm-run-path | 6.0.0 | npm | MIT |
+| npm-to-yarn | 3.0.1 | npm | MIT |
+| nth-check | 2.1.1 | npm | BSD-2-Clause |
+| nwsapi | 2.2.23 | npm | MIT |
+| object-assign | 4.1.1 | npm | MIT |
+| object-inspect | 1.13.4 | npm | MIT |
+| object-treeify | 1.1.33 | npm | MIT |
+| ofetch | 2.0.0-alpha.3 | npm | MIT |
+| ohash | 2.0.11 | npm | MIT |
+| on-finished | 2.4.1 | npm | MIT |
+| once | 1.4.0 | npm | ISC |
+| onetime | 5.1.2 | npm | MIT |
+| onetime | 7.0.0 | npm | MIT |
+| oniguruma-parser | 0.12.1 | npm | MIT |
+| oniguruma-to-es | 4.3.4 | npm | MIT |
+| open | 11.0.0 | npm | MIT |
+| ora | 8.2.0 | npm | MIT |
+| outvariant | 1.4.3 | npm | MIT |
+| oxc-minify | 0.96.0 | npm | MIT |
+| oxc-transform | 0.96.0 | npm | MIT |
+| oxfmt | 0.19.0 | npm | MIT |
+| oxlint | 1.35.0 | npm | MIT |
+| package-manager-detector | 1.6.0 | npm | MIT |
+| pako | 0.2.9 | npm | MIT |
+| parent-module | 1.0.1 | npm | MIT |
+| parse-css-color | 0.2.1 | npm | MIT |
+| parse-entities | 4.0.2 | npm | MIT |
+| parse-json | 5.2.0 | npm | MIT |
+| parse-ms | 4.0.0 | npm | MIT |
+| parse5 | 7.3.0 | npm | MIT |
+| parse5-htmlparser2-tree-adapter | 7.1.0 | npm | MIT |
+| parse5-parser-stream | 7.1.2 | npm | MIT |
+| parseurl | 1.3.3 | npm | MIT |
+| path-browserify | 1.0.1 | npm | MIT |
+| path-key | 3.1.1 | npm | MIT |
+| path-key | 4.0.0 | npm | MIT |
+| path-to-regexp | 6.3.0 | npm | MIT |
+| path-to-regexp | 8.3.0 | npm | MIT |
+| pathe | 2.0.3 | npm | MIT |
+| picocolors | 1.1.1 | npm | ISC |
+| picomatch | 2.3.1 | npm | MIT |
+| picomatch | 4.0.3 | npm | MIT |
+| pkce-challenge | 5.0.1 | npm | MIT |
+| postcss | 8.5.6 | npm | MIT |
+| postcss-selector-parser | 6.0.10 | npm | MIT |
+| postcss-selector-parser | 7.1.1 | npm | MIT |
+| postcss-value-parser | 4.2.0 | npm | MIT |
+| posthog-js | 1.310.1 | npm | non-standard |
+| powershell-utils | 0.1.0 | npm | MIT |
+| preact | 10.28.1 | npm | MIT |
+| prettier | 3.7.4 | npm | MIT |
+| pretty-format | 27.5.1 | npm | MIT |
+| pretty-ms | 9.3.0 | npm | MIT |
+| prismjs | 1.30.0 | npm | MIT |
+| prompts | 2.4.2 | npm | MIT |
+| property-information | 7.1.0 | npm | MIT |
+| proxy-addr | 2.0.7 | npm | MIT |
+| punycode | 2.3.1 | npm | MIT |
+| qs | 6.14.0 | npm | BSD-3-Clause |
+| queue-microtask | 1.2.3 | npm | MIT |
+| radix-ui | 1.4.3 | npm | MIT |
+| range-parser | 1.2.1 | npm | MIT |
+| raw-body | 3.0.2 | npm | MIT |
+| react | 19.2.3 | npm | MIT |
+| react-dom | 19.2.3 | npm | MIT |
+| react-is | 17.0.2 | npm | MIT |
+| react-markdown | 10.1.0 | npm | MIT |
+| react-medium-image-zoom | 5.4.0 | npm | BSD-3-Clause |
+| react-refresh | 0.18.0 | npm | MIT |
+| react-remove-scroll | 2.7.2 | npm | MIT |
+| react-remove-scroll-bar | 2.3.8 | npm | MIT |
+| react-style-singleton | 2.2.3 | npm | MIT |
+| react-syntax-highlighter | 16.1.0 | npm | MIT |
+| readdirp | 3.6.0 | npm | MIT |
+| readdirp | 5.0.0 | npm | MIT |
+| recast | 0.23.11 | npm | MIT |
+| recma-build-jsx | 1.0.0 | npm | MIT |
+| recma-jsx | 1.0.1 | npm | MIT |
+| recma-parse | 1.0.0 | npm | MIT |
+| recma-stringify | 1.0.0 | npm | MIT |
+| refractor | 5.0.0 | npm | MIT |
+| regex | 6.1.0 | npm | MIT |
+| regex-recursion | 6.0.2 | npm | MIT |
+| regex-utilities | 2.3.0 | npm | MIT |
+| rehype-recma | 1.0.0 | npm | MIT |
+| remark | 15.0.1 | npm | MIT |
+| remark-gfm | 4.0.1 | npm | MIT |
+| remark-mdx | 3.1.1 | npm | MIT |
+| remark-parse | 11.0.0 | npm | MIT |
+| remark-rehype | 11.1.2 | npm | MIT |
+| remark-stringify | 11.0.0 | npm | MIT |
+| require-directory | 2.1.1 | npm | MIT |
+| require-from-string | 2.0.2 | npm | MIT |
+| reselect | 5.1.1 | npm | MIT |
+| resolve-from | 4.0.0 | npm | MIT |
+| resolve-pkg-maps | 1.0.0 | npm | MIT |
+| restore-cursor | 5.1.0 | npm | MIT |
+| rettime | 0.7.0 | npm | MIT |
+| reusify | 1.1.0 | npm | MIT |
+| rollup | 4.54.0 | npm | MIT |
+| rou3 | 0.7.12 | npm | MIT |
+| router | 2.2.0 | npm | MIT |
+| rrweb-cssom | 0.8.0 | npm | MIT |
+| run-applescript | 7.1.0 | npm | MIT |
+| run-parallel | 1.2.0 | npm | MIT |
+| safer-buffer | 2.1.2 | npm | MIT |
+| satori | 0.18.3 | npm | MPL-2.0 |
+| saxes | 6.0.0 | npm | ISC |
+| scheduler | 0.27.0 | npm | MIT |
+| scroll-into-view-if-needed | 3.1.0 | npm | MIT |
+| semver | 6.3.1 | npm | ISC |
+| send | 1.2.1 | npm | MIT |
+| seroval | 1.3.2 | npm | MIT |
+| seroval | 1.4.1 | npm | MIT |
+| seroval-plugins | 1.3.3 | npm | MIT |
+| seroval-plugins | 1.4.0 | npm | MIT |
+| serve-static | 2.2.1 | npm | MIT |
+| setprototypeof | 1.2.0 | npm | ISC |
+| shadcn | 3.6.2 | npm | MIT |
+| shebang-command | 2.0.0 | npm | MIT |
+| shebang-regex | 3.0.0 | npm | MIT |
+| shiki | 3.20.0 | npm | MIT |
+| side-channel | 1.1.0 | npm | MIT |
+| side-channel-list | 1.0.0 | npm | MIT |
+| side-channel-map | 1.0.1 | npm | MIT |
+| side-channel-weakmap | 1.0.2 | npm | MIT |
+| signal-exit | 3.0.7 | npm | ISC |
+| signal-exit | 4.1.0 | npm | ISC |
+| sisteransi | 1.0.5 | npm | MIT |
+| solid-js | 1.9.10 | npm | MIT |
+| sonner | 2.0.7 | npm | MIT |
+| source-map | 0.6.1 | npm | BSD-3-Clause |
+| source-map | 0.7.6 | npm | BSD-3-Clause |
+| source-map-js | 1.2.1 | npm | BSD-3-Clause |
+| space-separated-tokens | 2.0.2 | npm | MIT |
+| srvx | 0.8.16 | npm | MIT |
+| srvx | 0.9.8 | npm | MIT |
+| statuses | 2.0.2 | npm | MIT |
+| stdin-discarder | 0.2.2 | npm | MIT |
+| strict-event-emitter | 0.5.1 | npm | MIT |
+| string-width | 4.2.3 | npm | MIT |
+| string-width | 7.2.0 | npm | MIT |
+| string.prototype.codepointat | 0.2.1 | npm | MIT |
+| stringify-entities | 4.0.4 | npm | MIT |
+| stringify-object | 5.0.0 | npm | BSD-2-Clause |
+| strip-ansi | 6.0.1 | npm | MIT |
+| strip-ansi | 7.1.2 | npm | MIT |
+| strip-bom | 3.0.0 | npm | MIT |
+| strip-final-newline | 2.0.0 | npm | MIT |
+| strip-final-newline | 4.0.0 | npm | MIT |
+| style-to-js | 1.1.21 | npm | MIT |
+| style-to-object | 1.0.14 | npm | MIT |
+| symbol-tree | 3.2.4 | npm | MIT |
+| tabbable | 6.3.0 | npm | MIT |
+| tagged-tag | 1.0.0 | npm | MIT |
+| tailwind-merge | 3.4.0 | npm | MIT |
+| tailwindcss | 4.1.18 | npm | MIT |
+| tapable | 2.3.0 | npm | MIT |
+| tiny-inflate | 1.0.3 | npm | MIT |
+| tiny-invariant | 1.3.3 | npm | MIT |
+| tiny-warning | 1.0.3 | npm | MIT |
+| tinyexec | 1.0.2 | npm | MIT |
+| tinyglobby | 0.2.15 | npm | MIT |
+| tinypool | 2.0.0 | npm | MIT |
+| tldts | 6.1.86 | npm | MIT |
+| tldts | 7.0.19 | npm | MIT |
+| tldts-core | 6.1.86 | npm | MIT |
+| tldts-core | 7.0.19 | npm | MIT |
+| to-regex-range | 5.0.1 | npm | MIT |
+| toidentifier | 1.0.1 | npm | MIT |
+| tough-cookie | 5.1.2 | npm | BSD-3-Clause |
+| tough-cookie | 6.0.0 | npm | BSD-3-Clause |
+| tr46 | 5.1.1 | npm | MIT |
+| trim-lines | 3.0.1 | npm | MIT |
+| trough | 2.2.0 | npm | MIT |
+| ts-morph | 26.0.0 | npm | MIT |
+| tsconfck | 3.1.6 | npm | MIT |
+| tsconfig-paths | 4.2.0 | npm | MIT |
+| tslib | 2.8.1 | npm | 0BSD |
+| tsx | 4.21.0 | npm | MIT |
+| turbo | 2.7.1 | npm | MIT |
+| turbo-darwin-64 | 2.7.1 | npm | MIT |
+| turbo-darwin-arm64 | 2.7.1 | npm | MIT |
+| turbo-linux-64 | 2.7.1 | npm | MIT |
+| turbo-linux-arm64 | 2.7.1 | npm | MIT |
+| turbo-windows-64 | 2.7.1 | npm | MIT |
+| turbo-windows-arm64 | 2.7.1 | npm | MIT |
+| tw-animate-css | 1.4.0 | npm | MIT |
+| type-fest | 5.3.1 | npm | CC0-1.0 OR MIT |
+| type-is | 2.0.1 | npm | MIT |
+| typescript | 5.9.3 | npm | Apache-2.0 |
+| ufo | 1.6.1 | npm | MIT |
+| undici | 7.16.0 | npm | MIT |
+| undici-types | 7.16.0 | npm | MIT |
+| unenv | 2.0.0-rc.24 | npm | MIT |
+| unicode-trie | 2.0.0 | npm | MIT |
+| unicorn-magic | 0.3.0 | npm | MIT |
+| unified | 11.0.5 | npm | MIT |
+| unist-util-is | 6.0.1 | npm | MIT |
+| unist-util-position | 5.0.0 | npm | MIT |
+| unist-util-position-from-estree | 2.0.0 | npm | MIT |
+| unist-util-remove-position | 5.0.0 | npm | MIT |
+| unist-util-stringify-position | 4.0.0 | npm | MIT |
+| unist-util-visit | 5.0.0 | npm | MIT |
+| unist-util-visit-parents | 6.0.2 | npm | MIT |
+| universalify | 2.0.1 | npm | MIT |
+| unpipe | 1.0.0 | npm | MIT |
+| unplugin | 2.3.11 | npm | MIT |
+| unstorage | 2.0.0-alpha.4 | npm | MIT |
+| until-async | 3.0.2 | npm | MIT |
+| update-browserslist-db | 1.2.3 | npm | MIT |
+| use-callback-ref | 1.3.3 | npm | MIT |
+| use-sidecar | 1.1.3 | npm | MIT |
+| use-sync-external-store | 1.6.0 | npm | MIT |
+| util-deprecate | 1.0.2 | npm | MIT |
+| vary | 1.1.2 | npm | MIT |
+| vfile | 6.0.3 | npm | MIT |
+| vfile-message | 4.0.3 | npm | MIT |
+| vite | 7.3.0 | npm | MIT |
+| vite-tsconfig-paths | 5.1.4 | npm | MIT |
+| vite-tsconfig-paths | 6.0.3 | npm | MIT |
+| vitefu | 1.1.1 | npm | MIT |
+| w3c-xmlserializer | 5.0.0 | npm | MIT |
+| web-streams-polyfill | 3.3.3 | npm | MIT |
+| web-vitals | 4.2.4 | npm | Apache-2.0 |
+| web-vitals | 5.1.0 | npm | Apache-2.0 |
+| webidl-conversions | 7.0.0 | npm | BSD-2-Clause |
+| webpack-virtual-modules | 0.6.2 | npm | MIT |
+| whatwg-encoding | 3.1.1 | npm | MIT |
+| whatwg-mimetype | 4.0.0 | npm | MIT |
+| whatwg-url | 14.2.0 | npm | MIT |
+| which | 2.0.2 | npm | ISC |
+| which | 4.0.0 | npm | ISC |
+| wrap-ansi | 6.2.0 | npm | MIT |
+| wrap-ansi | 7.0.0 | npm | MIT |
+| wrappy | 1.0.2 | npm | ISC |
+| ws | 8.18.3 | npm | MIT |
+| wsl-utils | 0.3.0 | npm | MIT |
+| xml-name-validator | 5.0.0 | npm | Apache-2.0 |
+| xmlbuilder2 | 4.0.3 | npm | MIT |
+| xmlchars | 2.2.0 | npm | MIT |
+| y18n | 5.0.8 | npm | ISC |
+| yallist | 3.1.1 | npm | ISC |
+| yargs | 17.7.2 | npm | MIT |
+| yargs-parser | 21.1.1 | npm | ISC |
+| yoctocolors | 2.1.2 | npm | MIT |
+| yoctocolors-cjs | 2.1.3 | npm | MIT |
+| yoga-layout | 3.2.1 | npm | MIT |
+| zod | 3.25.76 | npm | MIT |
+| zod | 4.2.1 | npm | MIT |
+| zod-to-json-schema | 3.25.0 | npm | ISC |
+| zwitch | 2.0.4 | npm | MIT |


### PR DESCRIPTION
Adds a THIRD-PARTY-NOTICES.md file listing bundled open-source components and their licenses.